### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/run/etc/docker/compose/docker-compose.yaml
+++ b/run/etc/docker/compose/docker-compose.yaml
@@ -42,8 +42,8 @@ networks:
         - subnet: 192.168.0.0/24
 # Teilnetz des Netzes, das in "subnet" definiert ist, dessen IP-Adressen für Docker container verwendet werden können
 # Dieser Adressbereich muss vom DHCP-Server ignoriert werden, d.h. er darf diese Adresse niemandem zusteilen!!
-# Beispiel: iprange: 192.168.0.192/27 für den Bereich von 192.168.0.193 bis 192.168.0.222 (IP Calculator: http://jodies.de/ipcalc)
-          iprange: 192.168.0.192/27
+# Beispiel: ip_range: 192.168.0.192/27 für den Bereich von 192.168.0.193 bis 192.168.0.222 (IP Calculator: http://jodies.de/ipcalc)
+          ip_range: 192.168.0.192/27
 # Ziel der Default-Route (meist die interne IP-Adresses des Internet-Routers).
 # Beispiel: gateway: 192.168.0.1
           gateway: 192.168.0.1


### PR DESCRIPTION
Start des docker containers über systemd schlug fehl mit folgender Meldung:
docker-compose[29307]: networks.macvlan0.ipam.config value 'iprange' does not match any of the regexes: '^x-'
Debugging zeigte, dass der Parameter für das Teilnetz ip_range statt iprange heißen muss.