### PR TITLE
Update NotificationHandler.java

### DIFF
--- a/src/main/java/de/avanux/smartapplianceenabler/notification/NotificationHandler.java
+++ b/src/main/java/de/avanux/smartapplianceenabler/notification/NotificationHandler.java
@@ -73,8 +73,8 @@ public class NotificationHandler implements ApplianceIdConsumer {
     }
 
     protected boolean isRequestedNotification(NotificationType type) {
-        return this.requestedNotifications != null
-                && (this.requestedNotifications.getTypes() == null
+        return this.requestedNotifications == null
+                || (this.requestedNotifications.getTypes() == null
                 || this.requestedNotifications.getTypes().contains(type.name()));
     }
 


### PR DESCRIPTION
Fixed check for "isRequestedNotification" causing no notifications to be send when default value "all" was selected on switches or meters.